### PR TITLE
fix: add luatz as dependency

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,7 +43,6 @@ jobs:
     - name: Install Busted
       run: |
         /usr/local/openresty/luajit/bin/luarocks install busted
-        /usr/local/openresty/luajit/bin/luarocks install luatz
         /usr/local/openresty/luajit/bin/luarocks install luasocket
 
     - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -172,6 +172,11 @@ We set up an automated release workflow:
 1. Submit a PR with the name `feat: release vX.Y.Z`
 1. Merge PR with the commit name `feat: release vX.Y.Z`
 
+### 2.0.1 (10-Aug-2024)
+
+- fix: add luatz as dependency
+  [5](https://github.com/api7/lua-resty-aws/pull/5)
+
 ### 2.0.0 (09-Aug-2024)
 
 - feat: remove XML dependency to simplify installation

--- a/lua-resty-aws-dev-1.rockspec.template
+++ b/lua-resty-aws-dev-1.rockspec.template
@@ -27,6 +27,7 @@ dependencies = {
   "lua-resty-http >= 0.16",
   "lua-resty-luasocket ~> 1",
   "lua-resty-openssl >= 0.8.17",
+  "luatz = 0.4-1",
 }
 
 build = {


### PR DESCRIPTION
The `src/resty/aws/credentials/Credentials.lua` uses the `luatz` library to parse datetime strings, but it's not listed as a dependency on that library, so one would have to install luatz alongside lua-resty-aws, so fix it.