### PR TITLE
chore: upgrade lua-resty-openssl to support openssl 3.2

### DIFF
--- a/lua-resty-aws-dev-1.rockspec.template
+++ b/lua-resty-aws-dev-1.rockspec.template
@@ -26,7 +26,7 @@ dependencies = {
   "penlight ~> 1",
   "lua-resty-http >= 0.16",
   "lua-resty-luasocket ~> 1",
-  "lua-resty-openssl >= 0.8.17",
+  "lua-resty-openssl >= 0.8.26",
   "luatz = 0.4-1",
 }
 


### PR DESCRIPTION
Before https://github.com/fffonion/lua-resty-openssl/commit/1516b4d94ac4621a1b243c14b5133ded81515d28 , `lua-resty-openssl` can't work well with openssl 3.2.